### PR TITLE
Add call for attribute in svg-background

### DIFF
--- a/scss/tools/mixins/_svg-background.scss
+++ b/scss/tools/mixins/_svg-background.scss
@@ -2,14 +2,14 @@
 //
 // @include svg-background('<g transform="matrix(2.18679,0,0,2.18679,5.43964,-0.0421697)"><path d="M5.9 5.3L0.5 0.1C0.4 0 0.2 0 0.1 0.1 0 0.2 0 0.4 0.1 0.5L5.2 5.5 0.1 10.5C0 10.6 0 10.8 0.1 10.9 0.2 11 0.2 11 0.3 11 0.4 11 0.5 11 0.5 10.9L5.9 5.7C6 5.6 6 5.4 5.9 5.3Z"/></g>', black, 16);
 
-@mixin svg-background($svg, $color: $illusion-svg-background-color, $width: $illusion-svg-background-width, $height: $illusion-svg-background-height, $viewboxWidth: $illusion-svg-background-viewboxWidth, $viewboxHeight: $illusion-svg-background-viewboxHeight, $background-position: $illusion-svg-background-position, $background-repeat: $illusion-svg-background-repeat) {
+@mixin svg-background($svg, $color: $illusion-svg-background-color, $width: $illusion-svg-background-width, $height: $illusion-svg-background-height, $viewboxWidth: $illusion-svg-background-viewboxWidth, $viewboxHeight: $illusion-svg-background-viewboxHeight, $background-position: $illusion-svg-background-position, $background-repeat: $illusion-svg-background-repeat, $attribute: $illusion-svg-attribute) {
   @if $height == false {
     $height: $width;
   }
   @if $viewboxHeight == false {
     $viewboxHeight: $viewboxWidth;
   }
-  $svg-url: svg-url('<svg style="fill: #{$color};" xmlns="http://www.w3.org/2000/svg" width="#{$width}" height="#{$height}" viewBox="0 0 #{$viewboxWidth} #{$viewboxHeight}">#{$svg}</svg>');
+  $svg-url: svg-url('<svg style="fill: #{$color};" xmlns="http://www.w3.org/2000/svg" #{$attribute} width="#{$width}" height="#{$height}" viewBox="0 0 #{$viewboxWidth} #{$viewboxHeight}">#{$svg}</svg>');
   background-image: $svg-url;
   background-position: $background-position;
   background-repeat: $background-repeat;

--- a/scss/tools/variables/_svg.scss
+++ b/scss/tools/variables/_svg.scss
@@ -1,5 +1,6 @@
 // SVG background
 
+$illusion-svg-attribute:                "" !default;
 $illusion-svg-background-color:         black !default;
 $illusion-svg-background-width:         24 !default;
 $illusion-svg-background-height:        false !default;


### PR DESCRIPTION
I just stumbled upon a project where the current svg-background mixin was not complete.
A svg icon with attribute `xmlns:xlink="http://www.w3.org/1999/xlink"` in the `svg` element was needed to display the icon. 
This attribute is not present in the current svg-mixin. And the attribute is not needed for most implementations. Therefor I created this PR with a call to an empty attribute. But the scss developer has the freedom to add an attribute when needed. 

Example: 
```
  .icon--Credit-card {
    @include svg-background($payment--creditcard, $attribute: "xmlns:xlink=\"http://www.w3.org/1999/xlink\"");
  }
```